### PR TITLE
Migrate to gateway 0.6.0 client

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1244,13 +1244,13 @@ httpx = ">=0.25.0"
 
 [[package]]
 name = "ros2-medkit-client"
-version = "0.5.0"
+version = "0.6.0"
 description = "Async Python client for the ros2_medkit gateway"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "ros2_medkit_client-0.5.0-py3-none-any.whl", hash = "sha256:b8cacefb5bade0e975f7d5f8fbba32209e111942b19a566f0563f38a1f0d0e37"},
+    {file = "ros2_medkit_client-0.6.0-py3-none-any.whl", hash = "sha256:36806724b570105332563f26005049d42252004267d27b1a1ca648c8eba7c203"},
 ]
 
 [package.dependencies]
@@ -1263,7 +1263,7 @@ dev = ["pytest (>=8.0)", "pytest-asyncio (>=0.24)", "respx (>=0.22)", "ruff (>=0
 
 [package.source]
 type = "url"
-url = "https://github.com/selfpatch/ros2_medkit_clients/releases/download/py-v0.5.0/ros2_medkit_client-0.5.0-py3-none-any.whl"
+url = "https://github.com/selfpatch/ros2_medkit_clients/releases/download/py-v0.6.0/ros2_medkit_client-0.6.0-py3-none-any.whl"
 
 [[package]]
 name = "rpds-py"
@@ -1812,4 +1812,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "26a82b5b97d647f03b4dbca4029849a294c0dd015f721beb73fd145db98baa75"
+content-hash = "0a033fc8257acca535ed44168a80a7f2b842b0c4482d98b10f9c33d9d56b5db2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ros2-medkit-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "MCP server adapter for ros2_medkit SOVD HTTP API"
 authors = ["bburda <bartoszburda93@gmail.com>"]
 readme = "README.md"
@@ -15,7 +15,7 @@ pydantic = "^2.10.0"
 uvicorn = { version = "^0.34.0", extras = ["standard"] }
 starlette = "^0.45.0"
 # Distributed via GitHub Releases wheel (no PyPI yet). Replace with version constraint when available.
-ros2-medkit-client = {url = "https://github.com/selfpatch/ros2_medkit_clients/releases/download/py-v0.5.0/ros2_medkit_client-0.5.0-py3-none-any.whl"}
+ros2-medkit-client = {url = "https://github.com/selfpatch/ros2_medkit_clients/releases/download/py-v0.6.0/ros2_medkit_client-0.6.0-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.0"

--- a/src/ros2_medkit_mcp/__init__.py
+++ b/src/ros2_medkit_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ros2_medkit_mcp - MCP adapter for ros2_medkit SOVD HTTP API."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/ros2_medkit_mcp/client.py
+++ b/src/ros2_medkit_mcp/client.py
@@ -644,12 +644,15 @@ class SovdClient:
             raise SovdClientError(message=f"Request failed: {e}") from e
 
     async def _raw_get_items(self, path: str, params: dict[str, str]) -> list[dict[str, Any]]:
-        """GET a collection via raw httpx with query parameters.
+        """GET a collection via raw httpx with string query parameters.
 
-        The 0.5.0 generated client cannot pass query parameters: the spec omits
-        them even though the gateway reads them (see selfpatch/ros2_medkit#416).
-        Use raw httpx for filtered list calls until the client is regenerated
-        from the fixed spec. Path segments must be pre-encoded by the caller.
+        The generated per-endpoint list functions type their filter parameters
+        as endpoint-specific enums (e.g. ``ListComponentFaultsStatus``,
+        ``ListComponentLogsSeverity``). Routing the filtered list calls (faults,
+        logs, updates) through this single helper passes plain string filters
+        straight through, instead of mapping each filter to its per-entity-type
+        enum and rejecting values the gateway would otherwise accept. Path
+        segments must be pre-encoded by the caller.
         """
         try:
             hc = await self._httpx_client()
@@ -1418,16 +1421,16 @@ class SovdClient:
         return await self._call(updates.get_update_status.asyncio, update_id=update_id)
 
     async def prepare_update(self, update_id: str) -> dict[str, Any]:
-        # 0.5.0: prepare is a body-less PUT returning 202 Accepted; the endpoint
-        # takes no request body.
+        # prepare is a body-less PUT returning 202 Accepted; the endpoint takes
+        # no request body.
         return await self._call_update_action(updates.prepare_update.asyncio, update_id=update_id)
 
     async def execute_update(self, update_id: str) -> dict[str, Any]:
-        # 0.5.0: execute is a body-less PUT returning 202 Accepted (see prepare_update).
+        # execute is a body-less PUT returning 202 Accepted (see prepare_update).
         return await self._call_update_action(updates.execute_update.asyncio, update_id=update_id)
 
     async def automate_update(self, update_id: str) -> dict[str, Any]:
-        # 0.5.0: automate is a body-less PUT returning 202 Accepted (see prepare_update).
+        # automate is a body-less PUT returning 202 Accepted (see prepare_update).
         return await self._call_update_action(updates.automate_update.asyncio, update_id=update_id)
 
     async def _call_update_action(self, api_func: Any, **kwargs: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Pin the gateway 0.6.0 client (`ros2_medkit_client` py-v0.6.0) and bump the package to 0.6.0. The 0.5.0 -> 0.6.0 change is additive (entity lifecycle status for apps and components); no behavioral changes were needed. The diff is only the wheel pin + version (`pyproject.toml`, `__init__.py`, `poetry.lock`) - no source or test edits.

---

## Issue

- closes #19

---

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

All gates pass UNCHANGED in a worktree branched from `origin/main`:

- `run_tests.py` - 168 passed
- `ruff check src/ tests/` - clean
- `ruff format --check src/ tests/` - clean
- `mypy src/` - clean

---

## Checklist

- [x] Breaking changes are clearly described (none - additive change only)
- [x] Linting passes (`poetry run ruff check src/ tests/`)
- [x] Formatting passes (`poetry run ruff format --check src/ tests/`)
- [x] Type checking passes (`poetry run mypy src/`)
- [x] Tests pass (`poetry run python run_tests.py`)
- [x] Docs were updated if behavior or public API changed (N/A - no API change)
